### PR TITLE
Harden Docker defaults for admin bootstrap and secrets

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,13 @@ prepare_db() {
     flask db_init
     flask db upgrade
     flask import_licenses_from_spdx
-    flask create_admin --login admin --email admin@admin.localhost --password password || true
+
+    if [ -n "${MOSP_ADMIN_PASSWORD:-}" ]; then
+        flask create_admin \
+            --login "${MOSP_ADMIN_LOGIN:-admin}" \
+            --email "${MOSP_ADMIN_EMAIL:-admin@admin.localhost}" \
+            --password "$MOSP_ADMIN_PASSWORD" || true
+    fi
 }
 
 # waiting for DB to come up

--- a/instance/docker.py
+++ b/instance/docker.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import secrets
 
 # Webserver
 HOST = os.getenv("HOST", "0.0.0.0")
@@ -27,8 +28,8 @@ SQLALCHEMY_DATABASE_URI = "postgresql://{user}:{password}@{host}:{port}/{name}".
 )
 SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv("SQLALCHEMY_TRACK_MODIFICATIONS", "0") == "1"
 
-SECRET_KEY = "LCx3BchmHRxFzkEv4BqQJyeXRLXenf"
-SECURITY_PASSWORD_SALT = "L8gTsyrpRQEF8jNWQPyvRfv7U5kJkD"
+SECRET_KEY = os.getenv("SECRET_KEY", secrets.token_urlsafe(32))
+SECURITY_PASSWORD_SALT = os.getenv("SECURITY_PASSWORD_SALT", secrets.token_urlsafe(32))
 
 LOG_PATH = "./var/log/mosp.log"
 LOG_LEVEL = "info"


### PR DESCRIPTION
### Motivation
- Remove insecure Docker defaults that created a predictable `admin/password` account and exposed static Flask signing secrets, which allowed remote takeover when the container was run with defaults.
- Make admin bootstrap and signing material opt-in or configurable so deployed containers do not ship public credentials or fixed `SECRET_KEY` values.

### Description
- Change `entrypoint.sh` so `flask create_admin` runs only when `MOSP_ADMIN_PASSWORD` is explicitly provided, with optional `MOSP_ADMIN_LOGIN` and `MOSP_ADMIN_EMAIL` overrides, instead of always creating `admin/password`.
- Update `instance/docker.py` to import `secrets` and set `SECRET_KEY` and `SECURITY_PASSWORD_SALT` from environment variables with secure random fallbacks via `secrets.token_urlsafe(32)`.
- Preserve existing behavior for users who explicitly provide `SECRET_KEY`, `SECURITY_PASSWORD_SALT`, or `MOSP_ADMIN_*` environment variables while removing unsafe defaults.

### Testing
- Ran `bash -n entrypoint.sh` which returned no syntax errors and succeeded.
- Ran `python -m py_compile instance/docker.py` which completed successfully with no compilation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df6bae27cc832fb4f4d0ffc6795b4e)